### PR TITLE
chart - Add dynamic Legend positions

### DIFF
--- a/src/PhpWord/Style/Chart.php
+++ b/src/PhpWord/Style/Chart.php
@@ -67,13 +67,7 @@ class Chart extends AbstractStyle
     private $showLegend = false;
 
     /**
-     * Chart legend Position. choices:
-     * r = right
-     * b = bottom
-     * t = top
-     * l = left
-
-     * default: right
+     * Chart legend Position. 
      *
      * @var string
      */
@@ -309,7 +303,13 @@ class Chart extends AbstractStyle
     }
 
     /**
-     * Set chart legend position
+     * Set chart legend position. choices:
+     * "r" - right of chart
+     * "b" - bottom of chart
+     * "t" - top of chart
+     * "l" - left of chart
+     *
+     * default: right
      *
      * @param bool $value
      */

--- a/src/PhpWord/Style/Chart.php
+++ b/src/PhpWord/Style/Chart.php
@@ -67,6 +67,19 @@ class Chart extends AbstractStyle
     private $showLegend = false;
 
     /**
+     * Chart legend Position. choices:
+     * r = right
+     * b = bottom
+     * t = top
+     * l = left
+
+     * default: right
+     *
+     * @var string
+     */
+    private $legendPosition = 'r';
+
+    /**
      * A list of display options for data labels
      *
      * @var array
@@ -281,6 +294,28 @@ class Chart extends AbstractStyle
     public function setShowLegend($value = false)
     {
         $this->showLegend = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get chart legend position
+     *
+     * @return string
+     */
+    public function getLegendPosition()
+    {
+        return $this->legendPosition;
+    }
+
+    /**
+     * Set chart legend position
+     *
+     * @param bool $value
+     */
+    public function setLegendPosition($value = 'r')
+    {
+        $this->legendPosition = $value;
 
         return $this;
     }

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -131,6 +131,7 @@ class Chart extends AbstractPart
 
         $title = $style->getTitle();
         $showLegend = $style->isShowLegend();
+        $legendPosition = $style->getLegendPosition();
 
         //Chart title
         if ($title) {
@@ -154,7 +155,7 @@ class Chart extends AbstractPart
 
         //Chart legend
         if ($showLegend) {
-            $xmlWriter->writeRaw('<c:legend><c:legendPos val="r"/></c:legend>');
+            $xmlWriter->writeRaw('<c:legend><c:legendPos val="'.$legendPosition.'"/></c:legend>');
         }
 
         $xmlWriter->startElement('c:plotArea');


### PR DESCRIPTION
### Description

The position of the legend of charts was always fixed to the right. Adding in the option to set it dynamically via a new option under styles/chart

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
